### PR TITLE
fix: use class method since the constructor is binding

### DIFF
--- a/days/041-044-react/demo/tips/src/App.js
+++ b/days/041-044-react/demo/tips/src/App.js
@@ -78,7 +78,7 @@ class App extends Component {
     })
   }
 
-  filterTips = (filterStr) => {
+  filterTips(filterStr){
     let tips = []
     for(const tip of this.state.orgTips){
       if(tip.tip && tip.tip.toLowerCase().includes(filterStr) ||


### PR DESCRIPTION
The arrow function syntax on a class property will create a new function bound to every instance of the App class that is made. So if you had 1000 App components rendered to the screen we would have 1000 copies of the same function each bound to their own instance.

The `.bind(this)` in the constructor takes a class method and binds it to the prototype, this means the 1000 apps each get the same reference to the single function that was created on the object prototype.

In this PR I change filterTips to a non-arrow function because it doesn't make sense to bind a class property arrow function. I haven't seen the videos, but if you wanted to demonstrate arrow functions then an alternate version of this PR would be to remove the `.bind(this)` call from the constructor for `filterTips` and leave it as an arrow function.