### PR TITLE
change day 9-12 requirements.txt and readme.md Day3 instruction to apistar==0.5.41 for package 0.6+ breaking changes

### DIFF
--- a/days/009-012-modern-apis-starred/demo/requirements.txt
+++ b/days/009-012-modern-apis-starred/demo/requirements.txt
@@ -1,2 +1,2 @@
-apistar
+apistar==0.5.41
 pytest

--- a/days/009-012-modern-apis-starred/readme.md
+++ b/days/009-012-modern-apis-starred/readme.md
@@ -12,7 +12,7 @@ For this day, you will get a data set from [Mockaroo](https://mockaroo.com/) or 
 
 Data is everywhere, but if you don't get inspiration maybe you can use this [Marvel dataset](https://raw.githubusercontent.com/pybites/marvel_challenge/master/marvel-wikia-data.csv) we used for one of our code challenges. If you don't know how to parse CSV, no worries: the same repo [has code for this](https://github.com/pybites/marvel_challenge/blob/solution/marvel.py).
 
-Next make a virtual env, activate it and `pip install apistar` as shown in the videos (of course you can also use `pipenv` or `Anaconda`).
+Next make a virtual env, activate it and `pip install apistar==0.5.41` as shown in the videos (of course you can also use `pipenv` or `Anaconda`).
 
 Then start to build your API using the skeleton from my demo. Try to implement the `GET` endpoint today (both all items and single item).
 


### PR DESCRIPTION
Raised a potential issue https://github.com/talkpython/100daysofweb-with-python-course/issues/5 for apistar package changes from 0.5.41 to 0.6+ that did away with servers (http://docs.apistar.com/). Not sure if my interpretation is correct, at least 0.7.2 did not work on my setup while 0.5.41 works, submitting PR in case this was indeed the case. 