### PR TITLE
Remove undefined `timenow` in 001-004-flask-intro

### DIFF
--- a/days/001-004-flask-intro/code/program/routes.py
+++ b/days/001-004-flask-intro/code/program/routes.py
@@ -1,10 +1,11 @@
+from datetime import datetime
 from flask import render_template
 from program import app
 
 @app.route('/')
 @app.route('/index')
 def index():
-    return render_template('index.html', title='Template Demo')
+    return render_template('index.html', title='Template Demo', time=datetime.now())
 
 @app.route('/100Days')
 def p100days():

--- a/days/001-004-flask-intro/code/program/routes.py
+++ b/days/001-004-flask-intro/code/program/routes.py
@@ -4,7 +4,7 @@ from program import app
 @app.route('/')
 @app.route('/index')
 def index():
-    return render_template('index.html', title='Template Demo', time=timenow)
+    return render_template('index.html', title='Template Demo')
 
 @app.route('/100Days')
 def p100days():


### PR DESCRIPTION
I came across the following error when I was playing around with the code.  Not sure if this error is by design.

```sh
[2021-03-17 06:27:03,870] ERROR in app: Exception on / [GET]
Traceback (most recent call last):
  File "/home/eric/code/serixscorpio/100daysofweb-with-python-course/days/001-004-flask-intro/code/venv/lib/python3.9/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/eric/code/serixscorpio/100daysofweb-with-python-course/days/001-004-flask-intro/code/venv/lib/python3.9/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/eric/code/serixscorpio/100daysofweb-with-python-course/days/001-004-flask-intro/code/venv/lib/python3.9/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/eric/code/serixscorpio/100daysofweb-with-python-course/days/001-004-flask-intro/code/venv/lib/python3.9/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/eric/code/serixscorpio/100daysofweb-with-python-course/days/001-004-flask-intro/code/venv/lib/python3.9/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/eric/code/serixscorpio/100daysofweb-with-python-course/days/001-004-flask-intro/code/venv/lib/python3.9/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/eric/code/serixscorpio/100daysofweb-with-python-course/days/001-004-flask-intro/code/program/routes.py", line 7, in index
    return render_template('index.html', title='Template Demo', time=timenow)
NameError: name 'timenow' is not defined

```

This is to fix "NameError: name 'timenow' is not defined".