### PR TITLE
Pin SQLAlchemy verison

### DIFF
--- a/days/033-036-sqlalchemy-orm/demo/hovershare_app_final/requirements.txt
+++ b/days/033-036-sqlalchemy-orm/demo/hovershare_app_final/requirements.txt
@@ -1,1 +1,1 @@
-sqlalchemy
+sqlalchemy==1.2.19

--- a/days/033-036-sqlalchemy-orm/demo/hovershare_app_starter/requirements.txt
+++ b/days/033-036-sqlalchemy-orm/demo/hovershare_app_starter/requirements.txt
@@ -1,1 +1,1 @@
-sqlalchemy
+sqlalchemy==1.2.19


### PR DESCRIPTION
Prior to this commit the requirements.txt did not pin a SQLAlchemy version.

Newer versions of SQLAlchemy removed the `relation` function used in the videos: https://github.com/sqlalchemy/sqlalchemy/blob/d519bca7f953a0520cda79504dbc019e74e87b28/lib/sqlalchemy/orm/__init__.py#L143

The demo code uses `relation` instead of the newer `relationship` function, so in order for the demo to work, users must install an older version of SQLAlchemy.

The videos used SQLAlchemy 1.2.10. This version is old enough that it is incompatible with with Python 3.10. Trying to execute the demo code yields the following error:

> AttributeError: module 'collections' has no attribute 'MutableMapping'

I found that version 1.2.19 was new enough to work with modern Python while still maintaining the `relation` function. This Pull Request pins 1.2.19 in the requirements.txt file so other students do not run into the same issue.